### PR TITLE
[BUGFIX] Call correct remove function in addMailboxData failure path.

### DIFF
--- a/p2p/src/main/java/bisq/network/p2p/P2PService.java
+++ b/p2p/src/main/java/bisq/network/p2p/P2PService.java
@@ -704,8 +704,14 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
                         // The p2PDataStorage.remove makes probably sense but need to be analysed more.
                         // Don't change that if it is not 100% clear.
                         sendMailboxMessageListener.onFault("Data already exists in our local database");
-                        boolean removeResult = p2PDataStorage.remove(protectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
-                        log.debug("remove result=" + removeResult);
+
+                        // Generate a new entry so sequence number is larger than previous add()
+                        ProtectedMailboxStorageEntry removeProtectedMailboxStorageEntry = p2PDataStorage.getMailboxDataWithSignedSeqNr(
+                                expirableMailboxStoragePayload,
+                                keyRing.getSignatureKeyPair(),
+                                receiversPublicKey);
+                        boolean removeResult = p2PDataStorage.removeMailboxData(removeProtectedMailboxStorageEntry, networkNode.getNodeAddress(), true);
+                        log.error("Unexpected state: adding mailbox message that already exists. removeMailboxData result=" + removeResult);
                     }
                 } catch (CryptoException e) {
                     log.error("Signing at getDataWithSignedSeqNr failed. That should never happen.");

--- a/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/P2PDataStorage.java
@@ -93,6 +93,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 @Slf4j
 public class P2PDataStorage implements MessageListener, ConnectionListener, PersistedDataHost {
     /**
@@ -475,6 +477,8 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
     public boolean remove(ProtectedStorageEntry protectedStorageEntry,
                           @Nullable NodeAddress sender,
                           boolean isDataOwner) {
+        checkArgument(!(protectedStorageEntry instanceof ProtectedMailboxStorageEntry), "Use removeMailboxData for ProtectedMailboxStorageEntry");
+
         ProtectedStoragePayload protectedStoragePayload = protectedStorageEntry.getProtectedStoragePayload();
         ByteArray hashOfPayload = get32ByteHashAsByteArray(protectedStoragePayload);
         boolean containsKey = map.containsKey(hashOfPayload);

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageTest.java
@@ -1169,12 +1169,7 @@ public class P2PDataStorageTest {
         }
 
 
-        // XXXBUGXXX: The P2PService calls remove() instead of removeFromMailbox() in the addMailboxData() path.
-        // This test shows it will always fail even with a valid remove entry. Future work should be able to
-        // combine the remove paths in the same way the add() paths are combined. This will require deprecating
-        // the receiversPubKey field which is a duplicate of the ownerPubKey in the MailboxStoragePayload.
-        // More investigation is needed.
-        @Test
+        @Test(expected = IllegalArgumentException.class)
         public void remove_canCallWrongRemoveAndFail() throws CryptoException {
 
             ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
@@ -1182,38 +1177,9 @@ public class P2PDataStorageTest {
 
             doProtectedStorageAddAndVerify(entryForAdd, true, true);
 
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForRemove);
-
             // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails
-            boolean addResult = super.doRemove(entryForRemove);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            // should succeed with expectedStatechange==true when remove paths are combined
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForRemove, false, this.expectIsDataOwner());
-        }
-
-        // TESTCASE: Verify misuse of the API (calling remove() instead of removeFromMailbox correctly errors with
-        // a payload that is valid for remove of a non-mailbox entry.
-        @Test
-        public void remove_canCallWrongRemoveAndFailInvalidPayload() throws CryptoException {
-
-            ProtectedStorageEntry entryForAdd = this.getProtectedStorageEntryForAdd(1);
-
-            doProtectedStorageAddAndVerify(entryForAdd, true, true);
-
-            SavedTestState beforeState = new SavedTestState(this.testState, entryForAdd);
-
-            // Call remove(ProtectedStorageEntry) instead of removeFromMailbox(ProtectedMailboxStorageEntry) and verify
-            // it fails with a payload that isn't signed by payload.ownerPubKey
-            boolean addResult = super.doRemove(entryForAdd);
-
-            if (!this.useMessageHandler)
-                Assert.assertFalse(addResult);
-
-            verifyProtectedStorageRemove(this.testState, beforeState, entryForAdd, false, this.expectIsDataOwner());
+            // it fails spectacularly
+            super.doRemove(entryForRemove);
         }
 
         // TESTCASE: Add after removed when add-once required (greater seq #)


### PR DESCRIPTION
Fix a bug where remove() was called instead of removeMailboxData() and
guard against future callers doing the same thing.

Additionally, fix a potential bug where the sequence number for the
remove was not incremented leading to unexpected add after remove behavior
documented in P2PDataStorageTest::addProtectectedStorageEntry_afterRemoveSameSeqNr().

For mailbox messages, this wouldn't actually be a problem due to the
AddOncePayload behavior, but all removes now increase the sequence number
making refactoring and analysis easier.